### PR TITLE
Create login and sign-up screen

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# Clerk Authentication
+EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your-clerk-publishable-key
+
+# API Configuration
+EXPO_PUBLIC_API_URL=http://localhost:3000/api
+EXPO_PUBLIC_API_URL_PROD=https://your-backend.vercel.app/api
+
+# Stripe
+EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your-stripe-publishable-key
+
+# App Configuration
+EXPO_PUBLIC_APP_ENV=development

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,13 +1,6 @@
-import { Redirect, Stack } from 'expo-router';
-import { useAuth } from '@clerk/clerk-expo';
+import { Stack } from 'expo-router';
 
 export default function AuthLayout() {
-  const { isSignedIn } = useAuth();
-
-  if (isSignedIn) {
-    return <Redirect href="/(tabs)" />;
-  }
-
   return (
     <Stack>
       <Stack.Screen 

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,153 +1,171 @@
-import React, { useState } from 'react';
+import { AppLayout } from '@/components/ui/AppLayout';
+import { GlassCard } from '@/components/ui/GlassCard';
+import { Ionicons } from '@expo/vector-icons';
+import { useFonts } from 'expo-font';
+import * as Haptics from 'expo-haptics';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Link, useRouter } from 'expo-router';
+import { useState } from 'react';
 import {
-  View,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
-  StyleSheet,
-  SafeAreaView,
-  KeyboardAvoidingView,
-  Platform,
-  Alert,
+  View,
 } from 'react-native';
-import { useSignIn, useOAuth } from '@clerk/clerk-expo';
-import { Link, useRouter } from 'expo-router';
-import { Ionicons } from '@expo/vector-icons';
 
 export default function LoginScreen() {
-  const { signIn, setActive, isLoaded } = useSignIn();
-  const { startOAuthFlow } = useOAuth({ strategy: 'oauth_google' });
   const router = useRouter();
-
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
 
+  const [fontsLoaded] = useFonts({
+    VT323: require('@/assets/fonts/VT323-Regular.ttf'),
+  });
+
+  if (!fontsLoaded) return null;
+
+  // Placeholder function for email/password login
   const handleSignIn = async () => {
-    if (!isLoaded) return;
+    if (!email || !password) {
+      Alert.alert('Error', 'Please fill in all fields');
+      return;
+    }
 
     setLoading(true);
-    try {
-      const result = await signIn.create({
-        identifier: email,
-        password,
-      });
-
-      if (result.status === 'complete') {
-        await setActive({ session: result.createdSessionId });
-        router.replace('/(tabs)');
-      } else {
-        console.log('Sign in incomplete', result);
-      }
-    } catch (err: any) {
-      Alert.alert('Error', err.errors?.[0]?.message || 'Sign in failed');
-    } finally {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    
+    // TODO: Implement actual authentication logic here
+    console.log('Login attempt:', { email, password });
+    
+    // Simulate API call
+    setTimeout(() => {
       setLoading(false);
-    }
+      Alert.alert('Success', 'Login functionality will be implemented later');
+      // router.replace('/(tabs)');
+    }, 1000);
   };
 
+  // Placeholder function for Google login
   const handleGoogleSignIn = async () => {
-    try {
-      const { createdSessionId, setActive } = await startOAuthFlow();
-      
-      if (createdSessionId) {
-        setActive!({ session: createdSessionId });
-        router.replace('/(tabs)');
-      }
-    } catch (err: any) {
-      Alert.alert('Error', 'Google sign in failed');
-    }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    
+    // TODO: Implement Google OAuth logic here
+    console.log('Google login attempt');
+    Alert.alert('Info', 'Google login functionality will be implemented later');
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <KeyboardAvoidingView 
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.keyboardView}
+    <AppLayout>
+      <LinearGradient
+        colors={['rgba(255,107,53,0.08)', '#232323', '#181818']}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        style={styles.gradient}
       >
-        <View style={styles.content}>
-          <View style={styles.header}>
-            <Text style={styles.title}>Welcome Back</Text>
-            <Text style={styles.subtitle}>Sign in to continue your productivity journey</Text>
-          </View>
-
-          <View style={styles.form}>
-            <View style={styles.inputContainer}>
-              <Text style={styles.label}>Email</Text>
-              <TextInput
-                style={styles.input}
-                value={email}
-                onChangeText={setEmail}
-                placeholder="Enter your email"
-                keyboardType="email-address"
-                autoCapitalize="none"
-                autoComplete="email"
-              />
+        <KeyboardAvoidingView 
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.container}
+        >
+          <ScrollView 
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Welcome Back</Text>
+              <Text style={styles.subtitle}>sign in to continue your journey</Text>
             </View>
 
-            <View style={styles.inputContainer}>
-              <Text style={styles.label}>Password</Text>
-              <TextInput
-                style={styles.input}
-                value={password}
-                onChangeText={setPassword}
-                placeholder="Enter your password"
-                secureTextEntry
-                autoComplete="password"
-              />
-            </View>
+            {/* Login Form */}
+            <GlassCard style={styles.formCard}>
+              <View style={styles.inputContainer}>
+                <Text style={styles.label}>Email</Text>
+                <TextInput
+                  style={styles.input}
+                  value={email}
+                  onChangeText={setEmail}
+                  placeholder="enter your email"
+                  placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoComplete="email"
+                />
+              </View>
 
-            <TouchableOpacity 
-              style={[styles.button, styles.primaryButton]}
-              onPress={handleSignIn}
-              disabled={loading || !email || !password}
-            >
-              <Text style={styles.primaryButtonText}>
-                {loading ? 'Signing In...' : 'Sign In'}
-              </Text>
-            </TouchableOpacity>
+              <View style={styles.inputContainer}>
+                <Text style={styles.label}>Password</Text>
+                <TextInput
+                  style={styles.input}
+                  value={password}
+                  onChangeText={setPassword}
+                  placeholder="enter your password"
+                  placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                  secureTextEntry
+                  autoComplete="password"
+                />
+              </View>
 
-            <View style={styles.divider}>
-              <View style={styles.dividerLine} />
-              <Text style={styles.dividerText}>or</Text>
-              <View style={styles.dividerLine} />
-            </View>
-
-            <TouchableOpacity 
-              style={[styles.button, styles.googleButton]}
-              onPress={handleGoogleSignIn}
-            >
-              <Ionicons name="logo-google" size={20} color="#4285F4" />
-              <Text style={styles.googleButtonText}>Continue with Google</Text>
-            </TouchableOpacity>
-          </View>
-
-          <View style={styles.footer}>
-            <Text style={styles.footerText}>Don't have an account? </Text>
-            <Link href="/(auth)/signup" asChild>
-              <TouchableOpacity>
-                <Text style={styles.linkText}>Sign Up</Text>
+              <TouchableOpacity 
+                style={[styles.button, styles.primaryButton]}
+                onPress={handleSignIn}
+                disabled={loading}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.primaryButtonText}>
+                  {loading ? 'signing in...' : 'sign in'}
+                </Text>
               </TouchableOpacity>
-            </Link>
-          </View>
-        </View>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+
+              <View style={styles.divider}>
+                <View style={styles.dividerLine} />
+                <Text style={styles.dividerText}>or</Text>
+                <View style={styles.dividerLine} />
+              </View>
+
+              <TouchableOpacity 
+                style={[styles.button, styles.googleButton]}
+                onPress={handleGoogleSignIn}
+                activeOpacity={0.8}
+              >
+                <Ionicons name="logo-google" size={20} color="#FF6B35" />
+                <Text style={styles.googleButtonText}>continue with google</Text>
+              </TouchableOpacity>
+            </GlassCard>
+
+            {/* Footer */}
+            <View style={styles.footer}>
+              <Text style={styles.footerText}>don't have an account? </Text>
+              <Link href="/(auth)/signup" asChild>
+                <TouchableOpacity activeOpacity={0.8}>
+                  <Text style={styles.linkText}>sign up</Text>
+                </TouchableOpacity>
+              </Link>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </LinearGradient>
+    </AppLayout>
   );
 }
 
 const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
-  keyboardView: {
-    flex: 1,
-  },
-  content: {
-    flex: 1,
-    padding: 24,
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 40,
   },
   header: {
     alignItems: 'center',
@@ -155,17 +173,26 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 32,
-    fontWeight: 'bold',
-    color: '#1f2937',
+    fontWeight: '400',
+    color: '#fff',
+    fontFamily: 'VT323',
+    letterSpacing: 2,
+    textTransform: 'lowercase',
+    textShadowColor: 'rgba(255, 107, 53, 0.18)',
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 8,
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 16,
-    color: '#6b7280',
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontFamily: 'Inter',
     textAlign: 'center',
+    textTransform: 'lowercase',
   },
-  form: {
-    marginBottom: 40,
+  formCard: {
+    padding: 24,
+    marginBottom: 32,
   },
   inputContainer: {
     marginBottom: 20,
@@ -173,16 +200,20 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#374151',
+    color: '#FFFFFF',
     marginBottom: 8,
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   input: {
     borderWidth: 1,
-    borderColor: '#d1d5db',
+    borderColor: 'rgba(255, 255, 255, 0.2)',
     borderRadius: 12,
     padding: 16,
     fontSize: 16,
-    backgroundColor: '#f9fafb',
+    color: '#FFFFFF',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    fontFamily: 'Inter',
   },
   button: {
     borderRadius: 12,
@@ -191,26 +222,35 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   primaryButton: {
-    backgroundColor: '#3b82f6',
+    backgroundColor: '#FF6B35',
+    shadowColor: '#FF6B35',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 8,
   },
   primaryButtonText: {
-    color: '#fff',
+    color: '#FFFFFF',
     fontSize: 16,
     fontWeight: '600',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   googleButton: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
     borderWidth: 1,
-    borderColor: '#d1d5db',
+    borderColor: 'rgba(255, 107, 53, 0.3)',
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    gap: 8,
+    gap: 12,
   },
   googleButtonText: {
-    color: '#374151',
+    color: '#FFFFFF',
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: '500',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   divider: {
     flexDirection: 'row',
@@ -220,13 +260,14 @@ const styles = StyleSheet.create({
   dividerLine: {
     flex: 1,
     height: 1,
-    backgroundColor: '#e5e7eb',
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
   },
   dividerText: {
-    marginLeft: 16,
-    marginRight: 16,
-    color: '#6b7280',
+    marginHorizontal: 16,
+    color: 'rgba(255, 255, 255, 0.6)',
     fontSize: 14,
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   footer: {
     flexDirection: 'row',
@@ -235,11 +276,15 @@ const styles = StyleSheet.create({
   },
   footerText: {
     fontSize: 16,
-    color: '#6b7280',
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   linkText: {
     fontSize: 16,
-    color: '#3b82f6',
+    color: '#FF6B35',
     fontWeight: '600',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
 }); 

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,181 +1,198 @@
-import React, { useState } from 'react';
+import { AppLayout } from '@/components/ui/AppLayout';
+import { GlassCard } from '@/components/ui/GlassCard';
+import { Ionicons } from '@expo/vector-icons';
+import { useFonts } from 'expo-font';
+import * as Haptics from 'expo-haptics';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Link, useRouter } from 'expo-router';
+import { useState } from 'react';
 import {
-  View,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
-  StyleSheet,
-  SafeAreaView,
-  KeyboardAvoidingView,
-  Platform,
-  Alert,
+  View,
 } from 'react-native';
-import { useSignUp, useOAuth } from '@clerk/clerk-expo';
-import { Link, useRouter } from 'expo-router';
-import { Ionicons } from '@expo/vector-icons';
 
 export default function SignUpScreen() {
-  const { signUp, setActive, isLoaded } = useSignUp();
-  const { startOAuthFlow } = useOAuth({ strategy: 'oauth_google' });
   const router = useRouter();
-
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [loading, setLoading] = useState(false);
 
+  const [fontsLoaded] = useFonts({
+    VT323: require('@/assets/fonts/VT323-Regular.ttf'),
+  });
+
+  if (!fontsLoaded) return null;
+
+  // Placeholder function for email/password signup
   const handleSignUp = async () => {
-    if (!isLoaded) return;
+    if (!email || !password || !firstName) {
+      Alert.alert('Error', 'Please fill in all required fields');
+      return;
+    }
 
     setLoading(true);
-    try {
-      const result = await signUp.create({
-        emailAddress: email,
-        password,
-        firstName,
-        lastName,
-      });
-
-      if (result.status === 'complete') {
-        await setActive({ session: result.createdSessionId });
-        router.replace('/(tabs)');
-      } else {
-        // Handle email verification if needed
-        console.log('Sign up incomplete', result);
-      }
-    } catch (err: any) {
-      Alert.alert('Error', err.errors?.[0]?.message || 'Sign up failed');
-    } finally {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    
+    // TODO: Implement actual signup logic here
+    console.log('Signup attempt:', { email, password, firstName, lastName });
+    
+    // Simulate API call
+    setTimeout(() => {
       setLoading(false);
-    }
+      Alert.alert('Success', 'Signup functionality will be implemented later');
+      // router.replace('/(tabs)');
+    }, 1000);
   };
 
+  // Placeholder function for Google signup
   const handleGoogleSignUp = async () => {
-    try {
-      const { createdSessionId, setActive } = await startOAuthFlow();
-      
-      if (createdSessionId) {
-        setActive!({ session: createdSessionId });
-        router.replace('/(tabs)');
-      }
-    } catch (err: any) {
-      Alert.alert('Error', 'Google sign up failed');
-    }
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    
+    // TODO: Implement Google OAuth logic here
+    console.log('Google signup attempt');
+    Alert.alert('Info', 'Google signup functionality will be implemented later');
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <KeyboardAvoidingView 
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.keyboardView}
+    <AppLayout>
+      <LinearGradient
+        colors={['rgba(255,107,53,0.08)', '#232323', '#181818']}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        style={styles.gradient}
       >
-        <View style={styles.content}>
-          <View style={styles.header}>
-            <Text style={styles.title}>Create Account</Text>
-            <Text style={styles.subtitle}>Join thousands boosting their productivity</Text>
-          </View>
+        <KeyboardAvoidingView 
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.container}
+        >
+          <ScrollView 
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Create Account</Text>
+              <Text style={styles.subtitle}>join the productivity revolution</Text>
+            </View>
 
-          <View style={styles.form}>
-            <View style={styles.row}>
-              <View style={[styles.inputContainer, styles.halfWidth]}>
-                <Text style={styles.label}>First Name</Text>
+            {/* Signup Form */}
+            <GlassCard style={styles.formCard}>
+              <View style={styles.row}>
+                <View style={[styles.inputContainer, styles.halfWidth]}>
+                  <Text style={styles.label}>First Name</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={firstName}
+                    onChangeText={setFirstName}
+                    placeholder="first name"
+                    placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                    autoComplete="given-name"
+                  />
+                </View>
+                <View style={[styles.inputContainer, styles.halfWidth]}>
+                  <Text style={styles.label}>Last Name</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={lastName}
+                    onChangeText={setLastName}
+                    placeholder="last name"
+                    placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                    autoComplete="family-name"
+                  />
+                </View>
+              </View>
+
+              <View style={styles.inputContainer}>
+                <Text style={styles.label}>Email</Text>
                 <TextInput
                   style={styles.input}
-                  value={firstName}
-                  onChangeText={setFirstName}
-                  placeholder="First name"
-                  autoComplete="given-name"
+                  value={email}
+                  onChangeText={setEmail}
+                  placeholder="enter your email"
+                  placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoComplete="email"
                 />
               </View>
-              <View style={[styles.inputContainer, styles.halfWidth]}>
-                <Text style={styles.label}>Last Name</Text>
+
+              <View style={styles.inputContainer}>
+                <Text style={styles.label}>Password</Text>
                 <TextInput
                   style={styles.input}
-                  value={lastName}
-                  onChangeText={setLastName}
-                  placeholder="Last name"
-                  autoComplete="family-name"
+                  value={password}
+                  onChangeText={setPassword}
+                  placeholder="create a password"
+                  placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                  secureTextEntry
+                  autoComplete="new-password"
                 />
               </View>
-            </View>
 
-            <View style={styles.inputContainer}>
-              <Text style={styles.label}>Email</Text>
-              <TextInput
-                style={styles.input}
-                value={email}
-                onChangeText={setEmail}
-                placeholder="Enter your email"
-                keyboardType="email-address"
-                autoCapitalize="none"
-                autoComplete="email"
-              />
-            </View>
-
-            <View style={styles.inputContainer}>
-              <Text style={styles.label}>Password</Text>
-              <TextInput
-                style={styles.input}
-                value={password}
-                onChangeText={setPassword}
-                placeholder="Create a password"
-                secureTextEntry
-                autoComplete="new-password"
-              />
-            </View>
-
-            <TouchableOpacity 
-              style={[styles.button, styles.primaryButton]}
-              onPress={handleSignUp}
-              disabled={loading || !email || !password || !firstName}
-            >
-              <Text style={styles.primaryButtonText}>
-                {loading ? 'Creating Account...' : 'Create Account'}
-              </Text>
-            </TouchableOpacity>
-
-            <View style={styles.divider}>
-              <View style={styles.dividerLine} />
-              <Text style={styles.dividerText}>or</Text>
-              <View style={styles.dividerLine} />
-            </View>
-
-            <TouchableOpacity 
-              style={[styles.button, styles.googleButton]}
-              onPress={handleGoogleSignUp}
-            >
-              <Ionicons name="logo-google" size={20} color="#4285F4" />
-              <Text style={styles.googleButtonText}>Continue with Google</Text>
-            </TouchableOpacity>
-          </View>
-
-          <View style={styles.footer}>
-            <Text style={styles.footerText}>Already have an account? </Text>
-            <Link href="/(auth)/login" asChild>
-              <TouchableOpacity>
-                <Text style={styles.linkText}>Sign In</Text>
+              <TouchableOpacity 
+                style={[styles.button, styles.primaryButton]}
+                onPress={handleSignUp}
+                disabled={loading}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.primaryButtonText}>
+                  {loading ? 'creating account...' : 'create account'}
+                </Text>
               </TouchableOpacity>
-            </Link>
-          </View>
-        </View>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+
+              <View style={styles.divider}>
+                <View style={styles.dividerLine} />
+                <Text style={styles.dividerText}>or</Text>
+                <View style={styles.dividerLine} />
+              </View>
+
+              <TouchableOpacity 
+                style={[styles.button, styles.googleButton]}
+                onPress={handleGoogleSignUp}
+                activeOpacity={0.8}
+              >
+                <Ionicons name="logo-google" size={20} color="#FF6B35" />
+                <Text style={styles.googleButtonText}>continue with google</Text>
+              </TouchableOpacity>
+            </GlassCard>
+
+            {/* Footer */}
+            <View style={styles.footer}>
+              <Text style={styles.footerText}>already have an account? </Text>
+              <Link href="/(auth)/login" asChild>
+                <TouchableOpacity activeOpacity={0.8}>
+                  <Text style={styles.linkText}>sign in</Text>
+                </TouchableOpacity>
+              </Link>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </LinearGradient>
+    </AppLayout>
   );
 }
 
 const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
-  keyboardView: {
-    flex: 1,
-  },
-  content: {
-    flex: 1,
-    padding: 24,
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 40,
   },
   header: {
     alignItems: 'center',
@@ -183,17 +200,26 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 32,
-    fontWeight: 'bold',
-    color: '#1f2937',
+    fontWeight: '400',
+    color: '#fff',
+    fontFamily: 'VT323',
+    letterSpacing: 2,
+    textTransform: 'lowercase',
+    textShadowColor: 'rgba(255, 107, 53, 0.18)',
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 8,
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 16,
-    color: '#6b7280',
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontFamily: 'Inter',
     textAlign: 'center',
+    textTransform: 'lowercase',
   },
-  form: {
-    marginBottom: 40,
+  formCard: {
+    padding: 24,
+    marginBottom: 32,
   },
   row: {
     flexDirection: 'row',
@@ -208,16 +234,20 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#374151',
+    color: '#FFFFFF',
     marginBottom: 8,
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   input: {
     borderWidth: 1,
-    borderColor: '#d1d5db',
+    borderColor: 'rgba(255, 255, 255, 0.2)',
     borderRadius: 12,
     padding: 16,
     fontSize: 16,
-    backgroundColor: '#f9fafb',
+    color: '#FFFFFF',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    fontFamily: 'Inter',
   },
   button: {
     borderRadius: 12,
@@ -226,26 +256,35 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   primaryButton: {
-    backgroundColor: '#3b82f6',
+    backgroundColor: '#FF6B35',
+    shadowColor: '#FF6B35',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 8,
   },
   primaryButtonText: {
-    color: '#fff',
+    color: '#FFFFFF',
     fontSize: 16,
     fontWeight: '600',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   googleButton: {
-    backgroundColor: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
     borderWidth: 1,
-    borderColor: '#d1d5db',
+    borderColor: 'rgba(255, 107, 53, 0.3)',
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    gap: 8,
+    gap: 12,
   },
   googleButtonText: {
-    color: '#374151',
+    color: '#FFFFFF',
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: '500',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   divider: {
     flexDirection: 'row',
@@ -255,13 +294,14 @@ const styles = StyleSheet.create({
   dividerLine: {
     flex: 1,
     height: 1,
-    backgroundColor: '#e5e7eb',
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
   },
   dividerText: {
-    marginLeft: 16,
-    marginRight: 16,
-    color: '#6b7280',
+    marginHorizontal: 16,
+    color: 'rgba(255, 255, 255, 0.6)',
     fontSize: 14,
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   footer: {
     flexDirection: 'row',
@@ -270,11 +310,15 @@ const styles = StyleSheet.create({
   },
   footerText: {
     fontSize: 16,
-    color: '#6b7280',
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
   linkText: {
     fontSize: 16,
-    color: '#3b82f6',
+    color: '#FF6B35',
     fontWeight: '600',
+    fontFamily: 'Inter',
+    textTransform: 'lowercase',
   },
 }); 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,11 +1,10 @@
-import { Tabs } from 'expo-router';
-import React, { memo, useRef, useEffect, useState } from 'react';
-import { Platform, View, Animated } from 'react-native';
 import { HapticTab } from '@/components/HapticTab';
-import { Ionicons } from '@expo/vector-icons';
 import { GlassTabBar } from '@/components/ui/GlassTabBar';
-import { Lightning, CircleDashed, ChartLineUp, Hourglass, LightbulbIcon, TextboxIcon, TreeStructure, Brain } from 'phosphor-react-native';
-import { usePathname } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { Tabs, usePathname } from 'expo-router';
+import { Brain, Hourglass, LightbulbIcon, TextboxIcon } from 'phosphor-react-native';
+import React, { memo, useEffect, useRef } from 'react';
+import { Animated, Platform, View } from 'react-native';
 
 // Types
 type IoniconsName = keyof typeof Ionicons.glyphMap;
@@ -132,8 +131,13 @@ const renderTabBarBackground = () => (
 );
 
 export default function TabLayout() {
+  const { isSignedIn } = useAuth();
   const pathname = usePathname();
   const isOnMindMap = pathname === '/ideas-3d';
+
+  if (!isSignedIn) {
+    return <Redirect href="/(auth)/login" />;
+  }
 
   // Dynamic tab bar style based on current route
   const dynamicTabBarStyle = {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -131,13 +131,8 @@ const renderTabBarBackground = () => (
 );
 
 export default function TabLayout() {
-  const { isSignedIn } = useAuth();
   const pathname = usePathname();
   const isOnMindMap = pathname === '/ideas-3d';
-
-  if (!isSignedIn) {
-    return <Redirect href="/(auth)/login" />;
-  }
 
   // Dynamic tab bar style based on current route
   const dynamicTabBarStyle = {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,23 +16,6 @@ LogBox.ignoreLogs([
   'Warning: TRenderEngineProvider',
 ]);
 
-const tokenCache = {
-  async getToken(key: string) {
-    try {
-      return SecureStore.getItemAsync(key);
-    } catch (err) {
-      return null;
-    }
-  },
-  async saveToken(key: string, value: string) {
-    try {
-      return SecureStore.setItemAsync(key, value);
-    } catch (err) {
-      return;
-    }
-  },
-};
-
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
@@ -50,29 +33,17 @@ export default function RootLayout() {
     return null;
   }
 
-  const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!;
-
-  if (!publishableKey) {
-    throw new Error(
-      'Missing Publishable Key. Please set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env'
-    );
-  }
-
   return (
-    <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
-      <ClerkLoaded>
-        <RefreshProvider>
-          <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-            <Stack screenOptions={{ headerShown: false }}>
-              <Stack.Screen name="(auth)" />
-              <Stack.Screen name="(tabs)" />
-              <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
-              <Stack.Screen name="+not-found" />
-            </Stack>
-            <StatusBar style="light" backgroundColor="#272727" />
-          </ThemeProvider>
-        </RefreshProvider>
-      </ClerkLoaded>
-    </ClerkProvider>
+    <RefreshProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="(auth)" />
+          <Stack.Screen name="(tabs)" />
+          <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="light" backgroundColor="#272727" />
+      </ThemeProvider>
+    </RefreshProvider>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,9 @@
-// import { ClerkProvider, ClerkLoaded } from '@clerk/clerk-expo';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import { LogBox } from 'react-native';
-// import * as SecureStore from 'expo-secure-store';
 import 'react-native-reanimated';
 
 import { RefreshProvider } from '@/contexts/RefreshContext';
@@ -18,22 +16,22 @@ LogBox.ignoreLogs([
   'Warning: TRenderEngineProvider',
 ]);
 
-// const tokenCache = {
-//   async getToken(key: string) {
-//     try {
-//       return SecureStore.getItemAsync(key);
-//     } catch (err) {
-//       return null;
-//     }
-//   },
-//   async saveToken(key: string, value: string) {
-//     try {
-//       return SecureStore.setItemAsync(key, value);
-//     } catch (err) {
-//       return;
-//     }
-//   },
-// };
+const tokenCache = {
+  async getToken(key: string) {
+    try {
+      return SecureStore.getItemAsync(key);
+    } catch (err) {
+      return null;
+    }
+  },
+  async saveToken(key: string, value: string) {
+    try {
+      return SecureStore.setItemAsync(key, value);
+    } catch (err) {
+      return;
+    }
+  },
+};
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -52,21 +50,21 @@ export default function RootLayout() {
     return null;
   }
 
-  // const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!;
+  const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!;
 
-  // if (!publishableKey) {
-  //   throw new Error(
-  //     'Missing Publishable Key. Please set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env'
-  //   );
-  // }
+  if (!publishableKey) {
+    throw new Error(
+      'Missing Publishable Key. Please set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY in your .env'
+    );
+  }
 
   return (
-    // <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
-    //   <ClerkLoaded>
+    <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
+      <ClerkLoaded>
         <RefreshProvider>
           <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
             <Stack screenOptions={{ headerShown: false }}>
-              {/* <Stack.Screen name="(auth)" /> */}
+              <Stack.Screen name="(auth)" />
               <Stack.Screen name="(tabs)" />
               <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
               <Stack.Screen name="+not-found" />
@@ -74,7 +72,7 @@ export default function RootLayout() {
             <StatusBar style="light" backgroundColor="#272727" />
           </ThemeProvider>
         </RefreshProvider>
-    //   </ClerkLoaded>
-    // </ClerkProvider>
+      </ClerkLoaded>
+    </ClerkProvider>
   );
 }


### PR DESCRIPTION
Implement UI-only login and signup screens with Google buttons and placeholder functions, matching existing app design.

The previous implementation included full authentication logic with Clerk, which was not desired. This PR reverts those changes and focuses solely on the front-end UI for login and signup, ensuring design consistency and providing clear placeholders for future authentication integration.